### PR TITLE
Implement network-test.sh and workflow

### DIFF
--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -1,0 +1,20 @@
+name: Network Test
+
+on: push
+
+jobs:
+  test-network:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: sudo apt-get install mtr-tiny
+
+    - name: Run network-test.sh
+      run: bash ./network-test.sh
+      # This step assumes network-test.sh is executable and in the root directory of the repository
+
+    - name: Expose Output
+      run: echo "Network test output exposed in the workflow log"

--- a/network-test.sh
+++ b/network-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Fetch the GitHub API meta endpoint
+endpoints=$(curl -s https://api.github.com/meta | jq -r '.actions[] | select(endswith(".actions.githubusercontent.com"))')
+
+# Install mtr-tiny on the Ubuntu VM
+sudo apt-get update && sudo apt-get install -y mtr-tiny
+
+# Sequentially run mtr-tiny command on the first 3 endpoints
+for endpoint in $(echo "$endpoints" | head -n 3); do
+    echo "Running mtr-tiny for endpoint: $endpoint"
+    mtr --report --report-cycles=10 $endpoint
+done


### PR DESCRIPTION
Adds the `network-test.sh` script and a GitHub Actions workflow to run network tests as outlined in the project's README.md.

- **Script Implementation**: Adds `network-test.sh` which fetches GitHub API `meta` endpoint, installs `mtr-tiny`, and runs `mtr-tiny` command on the first 3 endpoints ending in `.actions.githubusercontent.com`.
- **GitHub Actions Workflow**: Introduces `.github/workflows/network-test.yml` that triggers on push events, uses an Ubuntu latest runner, checks out the repository, installs dependencies, runs the `network-test.sh` script, and exposes the output in the workflow log.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/actions-endpoint-network-test?shareId=07359498-2c2a-480e-856f-cb89f6c45f1e).