### PR TITLE
Update network-test.sh to output endpoints in JSON format

### DIFF
--- a/network-test.sh
+++ b/network-test.sh
@@ -3,6 +3,12 @@
 # Fetch the GitHub API meta endpoint
 endpoints=$(curl -s https://api.github.com/meta | jq -r '.actions[] | select(endswith(".actions.githubusercontent.com"))')
 
+# Extract the first 3 endpoints and format them into JSON
+endpoints_json=$(echo "$endpoints" | head -n 3 | jq -R . | jq -s .)
+
+# Echo the JSON formatted endpoints
+echo "Extracted endpoints in JSON format: $endpoints_json"
+
 # Install mtr-tiny on the Ubuntu VM
 sudo apt-get update && sudo apt-get install -y mtr-tiny
 


### PR DESCRIPTION
Updates the `network-test.sh` script to output the first 3 endpoints from the actions section of the meta API endpoint in JSON format.

- **JSON Formatting**: Extracts the first 3 endpoints and formats them into JSON using `jq`. This formatted output is then echoed to the terminal, aligning with the task's requirement to output the endpoints in JSON format.
- **Endpoint Processing**: Continues to sequentially run the `mtr-tiny` command on the first 3 endpoints, ensuring the script's functionality to analyze network performance remains intact.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/actions-endpoint-network-test?shareId=960aaf69-4af3-494f-910e-f43bf3724f15).