### PR TITLE
Expose endpoints JSON in workflow log

### DIFF
--- a/.github/workflows/network-test.yml
+++ b/.github/workflows/network-test.yml
@@ -16,5 +16,11 @@ jobs:
       run: bash ./network-test.sh
       # This step assumes network-test.sh is executable and in the root directory of the repository
 
+    - name: Upload endpoints_json output
+      uses: actions/upload-artifact@v2
+      with:
+        name: endpoints_json
+        path: endpoints_output.txt
+
     - name: Expose Output
       run: echo "Network test output exposed in the workflow log"

--- a/network-test.sh
+++ b/network-test.sh
@@ -6,8 +6,8 @@ endpoints=$(curl -s https://api.github.com/meta | jq -r '.actions[] | select(end
 # Extract the first 3 endpoints and format them into JSON
 endpoints_json=$(echo "$endpoints" | head -n 3 | jq -R . | jq -s .)
 
-# Echo the JSON formatted endpoints
-echo "Extracted endpoints in JSON format: $endpoints_json"
+# Echo the JSON formatted endpoints and save to a file
+echo "Extracted endpoints in JSON format: $endpoints_json" | tee endpoints_output.txt
 
 # Sequentially run mtr-tiny command on the first 3 endpoints
 for endpoint in $(echo "$endpoints" | head -n 3); do


### PR DESCRIPTION
Updates the `network-test.sh` script and the `.github/workflows/network-test.yml` workflow to enhance the visibility of the `endpoints_json` variable output in GitHub Actions.

- Modifies `network-test.sh` to echo the JSON formatted endpoints and simultaneously save this output to a file named `endpoints_output.txt`.
- Adds a step in `.github/workflows/network-test.yml` to upload the `endpoints_output.txt` file as an artifact, ensuring the JSON formatted endpoints are accessible after the workflow run.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/actions-endpoint-network-test?shareId=3a1c9a42-2f97-480f-b948-491031064a7d).