### PR TITLE
Implement mtr-tiny on first three actions endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@ tests the actions endpoints for connectivity
 
 This action will perform the following steps:
 
-1) connect to the GitHub api `meta` endpoint to `https://api.github.com/meta` retrieve the current list of endpoints for allow listing.
+1) Connect to the GitHub API `meta` endpoint to `https://api.github.com/meta` retrieve the current list of endpoints for allow listing.
 2) Parse the specific endpoints under the `actions` section that end in `.actions.githubusercontent.com`
-3) install `mtr-tiny` on the ubuntu vm
-4) Sequentially run `mtr-tiny` command on the first 3 endpoints, surfacing the active results in the actions workflow run log (outputting the command to terminal with echo)
-
+3) Install `mtr-tiny` on the ubuntu VM.
+4) Sequentially run `mtr-tiny` command on the first 3 endpoints, surfacing the active results in the actions workflow run log. This is now implemented directly in the `network-test.sh` script, ensuring that `mtr-tiny` is executed on the first three lines of the output from the script, providing concise and relevant connectivity diagnostics.
 

--- a/network-test.sh
+++ b/network-test.sh
@@ -9,5 +9,8 @@ actions=$(echo "$data" | jq -r '.domains.actions[]')
 # Filter the "actions" section to only keep endpoints that end with "actions.githubusercontent.com"
 actions=$(echo "$actions" | grep 'actions\.githubusercontent\.com$')
 
-# Print the filtered "actions" section
-echo "$actions"
+# Print the filtered "actions" section and run mtr-tiny on the first three lines
+echo "$actions" | head -n 3 | while read endpoint; do
+  echo "Running mtr-tiny on $endpoint"
+  mtr-tiny --report --report-cycles=10 "$endpoint"
+done


### PR DESCRIPTION
Updates the `network-test.sh` script and README.md to implement and document the execution of `mtr-tiny` on the first three lines of the output from the GitHub API.

- **Script Enhancement**: Modifies `network-test.sh` to not only print the filtered actions endpoints but also to run `mtr-tiny` on the first three lines of the output. This is achieved by piping the output to `head -n 3` and using a while loop to iterate over each endpoint, where `mtr-tiny` is executed with `--report` and `--report-cycles=10` flags for concise output.
- **Documentation Update**: Updates the README.md to accurately reflect the new functionality of `network-test.sh`. It now specifies that `mtr-tiny` is executed directly in the script, providing a clearer and more accurate description of the steps involved in the network test.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/actions-endpoint-network-test?shareId=c2361b79-cce9-43cb-a0a5-e0f06173670e).