### PR TITLE
Fix domain extraction in network-test.sh

### DIFF
--- a/network-test.sh
+++ b/network-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fetch the GitHub API meta endpoint
-endpoints=$(curl -s https://api.github.com/meta | jq -r '.actions[] | select(endswith(".actions.githubusercontent.com"))')
+endpoints=$(curl -s https://api.github.com/meta | jq -r '.actions.domains[]')
 
 # Extract the first 3 endpoints and format them into JSON
 endpoints_json=$(echo "$endpoints" | head -n 3 | jq -R . | jq -s .)


### PR DESCRIPTION
Updates the `network-test.sh` script to correctly extract and output the domains under 'actions' from `https://api.github.com/meta` in JSON format.

- Modifies the `jq` command to accurately parse the "domains" field under "actions" from the JSON output, ensuring the correct data is extracted.
- Maintains the functionality to echo the JSON formatted endpoints and save them to `endpoints_output.txt`, preserving the output's integrity.
- Continues to sequentially run `mtr-tiny` command on the first 3 endpoints, ensuring network performance testing remains unaffected by the changes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/actions-endpoint-network-test?shareId=10081aa5-6d9f-4415-9c9a-b7c3b305de65).